### PR TITLE
Fix runtime endpoint wiring for AIInterview plugin

### DIFF
--- a/src/Plugins/Nop.Plugin.Misc.AIInterview.Tests/RuntimeAndAdminTests.cs
+++ b/src/Plugins/Nop.Plugin.Misc.AIInterview.Tests/RuntimeAndAdminTests.cs
@@ -206,6 +206,22 @@ public class RuntimeAndAdminTests
         Assert.That(ex.Message, Is.EqualTo("Plugins.Misc.AIInterview.Admin.Invite.InvalidExpiry"));
     }
 
+    [Test]
+    public void AdminController_Has_ConfigureAction()
+    {
+        var method = typeof(MockAiInterviewAdminController).GetMethod("Configure", new[] { typeof(ConfigurationModel) });
+        Assert.That(method, Is.Not.Null);
+    }
+
+    [Test]
+    public void MockAiInterviewController_Has_EmployerActions()
+    {
+        var createMethod = typeof(MockAiInterviewController).GetMethod("CreateInvite");
+        var deactivateMethod = typeof(MockAiInterviewController).GetMethod("DeactivateInvite");
+        Assert.That(createMethod, Is.Not.Null);
+        Assert.That(deactivateMethod, Is.Not.Null);
+    }
+
     private class TestRuntimeController : MockAiInterviewController
     {
         public TestRuntimeController(IInterviewSessionService sessionService, ILocalizationService localizationService, IWorkContext workContext, ISponsorInviteService inviteService, ICreditService creditService, ICustomerService customerService)

--- a/src/Plugins/Nop.Plugin.Misc.AIInterview/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.AIInterview/Views/Configure.cshtml
@@ -5,7 +5,7 @@
     ViewBag.PageTitle = T("Plugins.Misc.AIInterview.Admin.Configure.Title").Text;
 }
 
-<form asp-controller="AIInterviewAdmin" asp-action="Configure" method="post">
+<form asp-controller="MockAiInterviewAdmin" asp-action="Configure" method="post">
     <div class="content-header clearfix">
         <h1 class="float-left">
             @T("Plugins.Misc.AIInterview.Admin.Configure.Title")

--- a/src/Plugins/Nop.Plugin.Misc.AIInterview/Views/MockAiInterview/EmployerManage.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.AIInterview/Views/MockAiInterview/EmployerManage.cshtml
@@ -24,7 +24,7 @@
             <div class="title">
                 <strong>@T("Plugins.Misc.AIInterview.Employer.Invite.CreateNew")</strong>
             </div>
-            <form asp-controller="AIInterviewEmployer" asp-action="CreateInvite" method="post">
+            <form asp-controller="MockAiInterview" asp-action="CreateInvite" method="post">
                 <div class="fieldset">
                     <div class="form-fields">
                         <div class="inputs">
@@ -83,7 +83,7 @@
                                     <td>
                                         @if (!invite.IsAccepted && (!invite.ExpiryDateUtc.HasValue || invite.ExpiryDateUtc > DateTime.UtcNow))
                                         {
-                                            <form asp-controller="AIInterviewEmployer" asp-action="DeactivateInvite" asp-route-id="@invite.Id" method="post">
+                                            <form asp-controller="MockAiInterview" asp-action="DeactivateInvite" asp-route-id="@invite.Id" method="post">
                                                 <button type="submit" class="button-2">@T("Plugins.Misc.AIInterview.Employer.Invite.Deactivate")</button>
                                             </form>
                                         }


### PR DESCRIPTION
This PR fixes the runtime endpoint wiring in the AIInterview plugin.
Specifically:
1. In `src/Plugins/Nop.Plugin.Misc.AIInterview/Views/Configure.cshtml`, the form target was changed from `AIInterviewAdmin` to `MockAiInterviewAdmin`.
2. In `src/Plugins/Nop.Plugin.Misc.AIInterview/Views/MockAiInterview/EmployerManage.cshtml`, the `CreateInvite` and `DeactivateInvite` form targets were changed from `AIInterviewEmployer` to `MockAiInterview`.
3. Tests were added to `src/Plugins/Nop.Plugin.Misc.AIInterview.Tests/RuntimeAndAdminTests.cs` to ensure these controller actions exist.

Verification:
- `dotnet build src/NopCommerce.sln` succeeded.
- `dotnet test src/Plugins/Nop.Plugin.Misc.AIInterview.Tests/Nop.Plugin.Misc.AIInterview.Tests.csproj` passed (41/41).
- `dotnet test src/Tests/Nop.Tests/Nop.Tests.csproj --filter "FullyQualifiedName~AIInterview|FullyQualifiedName~MockAiInterview"` passed (12/12).

---
*PR created automatically by Jules for task [17192353842403692180](https://jules.google.com/task/17192353842403692180) started by @sateeshmunagala*