### PR TITLE
feat: Transform Single Page Checkout to Two-Column Layout

### DIFF
--- a/src/Plugins/Nop.Plugin.Misc.SinglePageCheckout/Content/single-page-checkout.css
+++ b/src/Plugins/Nop.Plugin.Misc.SinglePageCheckout/Content/single-page-checkout.css
@@ -1,48 +1,176 @@
-.html-single-page-checkout .spc-container {
+.spc-two-columns-page .spc-container {
     display: flex;
     flex-wrap: wrap;
     margin: 0 -15px;
 }
 
-.html-single-page-checkout .spc-main-column {
-    flex: 0 0 100%;
-    max-width: 100%;
+.spc-two-columns-page .spc-left-column {
+    flex: 0 0 40%;
+    max-width: 40%;
     padding: 0 15px;
-    min-width: 0;
+    box-sizing: border-box;
 }
 
-.html-single-page-checkout .spc-sidebar-column {
-    flex: 0 0 100%;
-    max-width: 100%;
+.spc-two-columns-page .spc-right-column {
+    flex: 0 0 60%;
+    max-width: 60%;
     padding: 0 15px;
-    margin-top: 30px;
+    box-sizing: border-box;
 }
 
-.spc-sidebar-card {
-    background: #fff;
-    border: 1px solid #e1e1e1;
-    border-radius: 4px;
-    padding: 20px;
+@media (max-width: 991px) {
+    .spc-two-columns-page .spc-left-column,
+    .spc-two-columns-page .spc-right-column {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+}
+
+.spc-two-columns-page .spc-section {
     margin-bottom: 20px;
+    background: #fff;
+    border: 1px solid #ddd;
 }
 
-.spc-sidebar-card .title {
-    margin-top: 0;
-    margin-bottom: 15px;
+.spc-two-columns-page .spc-section-title {
+    background: #4ab2f1;
+    color: #fff;
+    padding: 10px 15px;
+}
+
+.spc-two-columns-page .spc-section-title h2 {
+    margin: 0;
+    font-size: 16px;
+}
+
+.spc-two-columns-page .spc-section-content {
+    padding: 15px;
+}
+
+.spc-two-columns-page .shipping-method-blocks,
+.spc-two-columns-page .payment-method-blocks {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0 -10px;
+}
+
+.spc-two-columns-page .method-card {
+    flex: 0 0 calc(50% - 20px);
+    margin: 10px;
+    padding: 15px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    cursor: pointer;
+    box-sizing: border-box;
+}
+
+.spc-two-columns-page .method-card input[type="radio"] {
+    display: none;
+}
+
+.spc-two-columns-page .method-card:has(input[type="radio"]:checked) {
+    border-color: #4ab2f1;
+    background-color: #f0f8ff;
+}
+
+.spc-two-columns-page .method-card label {
+    cursor: pointer;
+    display: block;
+    margin: 0;
+}
+
+.spc-two-columns-page .payment-logo {
+    max-height: 30px;
+    margin-right: 10px;
+    vertical-align: middle;
+}
+
+.spc-two-columns-page .spc-discounts-giftcards {
+    display: flex;
+    justify-content: space-between;
+    border: none;
+}
+
+.spc-two-columns-page .spc-discounts-giftcards .coupon-box,
+.spc-two-columns-page .spc-discounts-giftcards .giftcard-box {
+    flex: 0 0 calc(50% - 10px);
+    background: #fff;
+    border: 1px solid #ddd;
+}
+
+.spc-two-columns-page .spc-discounts-giftcards label {
+    display: block;
+    background: #4ab2f1;
+    color: #fff;
+    padding: 10px 15px;
+    margin: 0;
+    font-weight: bold;
+}
+
+.spc-two-columns-page .spc-discounts-giftcards .input-group {
+    display: flex;
+    padding: 15px;
+}
+
+.spc-two-columns-page .spc-discounts-giftcards input {
+    flex-grow: 1;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-right: none;
+}
+
+.spc-two-columns-page .spc-discounts-giftcards button {
+    padding: 8px 15px;
+    background: #999;
+    color: #fff;
+    border: 1px solid #999;
+    cursor: pointer;
+}
+
+.spc-two-columns-page .cart-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.spc-two-columns-page .cart-table th,
+.spc-two-columns-page .cart-table td {
+    padding: 10px;
+    border-bottom: 1px solid #ddd;
+    text-align: left;
+}
+
+.spc-two-columns-page .qty-container {
+    display: flex;
+    align-items: center;
+}
+
+.spc-two-columns-page .qty-container button {
+    width: 30px;
+    height: 30px;
+    background: #f0f0f0;
+    border: 1px solid #ccc;
+    cursor: pointer;
+}
+
+.spc-two-columns-page .qty-container input {
+    width: 40px;
+    height: 30px;
+    text-align: center;
+    border: 1px solid #ccc;
+    border-left: none;
+    border-right: none;
+}
+
+.spc-two-columns-page .confirm-order-button {
+    width: 100%;
+    padding: 15px;
     font-size: 18px;
-    border-bottom: 1px solid #eee;
-    padding-bottom: 10px;
+    background: #2087c8;
+    color: #fff;
+    border: none;
+    cursor: pointer;
 }
 
-@media (min-width: 1200px) {
-    .html-single-page-checkout .spc-main-column {
-        flex: 0 0 65%;
-        max-width: 65%;
-    }
-
-    .html-single-page-checkout .spc-sidebar-column {
-        flex: 0 0 35%;
-        max-width: 35%;
-        margin-top: 0;
-    }
+.spc-two-columns-page .confirm-order-button:hover {
+    background: #1a6fa3;
 }

--- a/src/Plugins/Nop.Plugin.Misc.SinglePageCheckout/Views/Index.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.SinglePageCheckout/Views/Index.cshtml
@@ -1,4 +1,4 @@
-@model SinglePageCheckoutPageModel
+@model Nop.Plugin.Misc.SinglePageCheckout.Models.SinglePageCheckoutPageModel
 @using Nop.Core
 @using Nop.Services.Customers
 @using Nop.Services.Helpers
@@ -13,223 +13,131 @@
     //title
     NopHtml.AddTitleParts(T("PageTitle.Checkout").Text);
     //page class
-    NopHtml.AppendPageCssClassParts("html-checkout-page html-single-page-checkout");
+    NopHtml.AppendPageCssClassParts("html-checkout-page html-single-page-checkout-two-columns");
 
     NopHtml.AddCssFileParts("~/Plugins/Misc.SinglePageCheckout/Content/single-page-checkout.css");
     NopHtml.AddScriptParts(ResourceLocation.Footer, "~/Plugins/Misc.SinglePageCheckout/Content/single-page-checkout.js");
 }
-@{
-    //step numbers
-    var billingAddressStepNumber = 1;
-    var shippingAddressStepNumber = 2;
-    var shippingMethodStepNumber = 3;
-    var paymentMethodStepNumber = 4;
-    var paymentInfoStepNumber = 5;
-    var confirmOrderStepNumber = 6;
-    if (!Model.CheckoutModel.ShippingRequired)
-    {
-        paymentMethodStepNumber = paymentMethodStepNumber - 2;
-        paymentInfoStepNumber = paymentInfoStepNumber - 2;
-        confirmOrderStepNumber = confirmOrderStepNumber - 2;
-    }
-    if (Model.CheckoutModel.DisableBillingAddressCheckoutStep)
-    {
-        shippingAddressStepNumber--;
-        shippingMethodStepNumber--;
-        paymentMethodStepNumber--;
-        paymentInfoStepNumber--;
-        confirmOrderStepNumber--;
-    }
-}
-<div class="page checkout-page">
+
+<div class="page checkout-page spc-two-columns-page">
     <div class="page-title">
         <h1>@T("Checkout")</h1>
     </div>
-    <div class="page-body checkout-data spc-container">
 
-        <div class="spc-main-column">
-            @await Component.InvokeAsync("Widget", new { widgetZone = Nop.Web.Framework.Infrastructure.PublicWidgetZones.OpcContentBefore, additionalData = Model.CheckoutModel })
-            <ol class="opc" id="checkout-steps">
-                <li id="opc-billing" class="tab-section allow">
-                    <div class="step-title">
-                        <span class="number">@billingAddressStepNumber</span>
-                        <h2 class="title">@T("Checkout.BillingAddress")</h2>
+    <div class="page-body spc-container">
+        <form id="spc-form" action="" method="post">
+
+            <div class="spc-left-column">
+                <!-- Billing Address -->
+                <div class="spc-section spc-billing-address" id="spc-billing-address">
+                    <div class="spc-section-title">
+                        <h2>@T("Checkout.BillingAddress")</h2>
                     </div>
-                    <div id="checkout-step-billing" class="step a-item" style="display: none;">
-                        <form id="co-billing-form" action="" method="post">
-                            <div id="checkout-billing-load">
-                                @await Html.PartialAsync("~/Views/Checkout/OpcBillingAddress.cshtml", Model.CheckoutModel.BillingAddress)
-                            </div>
-                        </form>
-                        <script asp-location="Footer">
-                            Billing.init('#co-billing-form', '@(storeLocation)checkout/OpcSaveBilling/', @(Model.CheckoutModel.DisableBillingAddressCheckoutStep.ToString().ToLowerInvariant()));
-                            if ($("#billing-address-select").length > 0) {
-                                Billing.newAddress(!$('#billing-address-select').val());
-                            }
-                        </script>
-                        <div class="buttons" id="billing-buttons-container">
-                            <span id="edit-billing-address-buttons">
-                                <button id="save-billing-address-button" type="button" class="button-1" style="display: none" onclick="Billing.saveEditAddress('@(storeLocation)checkout/SaveEditBillingAddress/'); return false;">@T("Common.Save")</button>
-                            </span>
-                            <button id="billing-continue-button" type="button" class="button-1 new-address-next-step-button" onclick="Billing.save()">@T("Common.Continue")</button>
-                            <span class="please-wait" id="billing-please-wait" style="display: none;">@T("Common.LoadingNextStep")</span>
-                        </div>
+                    <div class="spc-section-content">
+                        @await Html.PartialAsync("~/Views/Checkout/OpcBillingAddress.cshtml", Model.DataModel.BillingAddress)
                     </div>
-                </li>
-                @if (Model.CheckoutModel.ShippingRequired)
+                </div>
+
+                <!-- Shipping Address -->
+                @if (Model.DataModel.ShippingRequired)
                 {
-                    <li id="opc-shipping" class="tab-section">
-                        <div class="step-title">
-                            <span class="number">@shippingAddressStepNumber</span>
-                            <h2 class="title">@T("Checkout.ShippingAddress")</h2>
+                    <div class="spc-section spc-shipping-address" id="spc-shipping-address" style="display: @(Model.DataModel.BillingAddress.ShipToSameAddress ? "none" : "block");">
+                        <div class="spc-section-title">
+                            <h2>@T("Checkout.ShippingAddress")</h2>
                         </div>
-                        <div id="checkout-step-shipping" class="step a-item" style="display: none;">
-                            <form action="" id="co-shipping-form" method="post">
-                                <div id="checkout-shipping-load">
-                                    @*shipping address content will be loaded here*@
-                                </div>
-                            </form>
-                            <script asp-location="Footer">
-                                Shipping.init('#co-shipping-form', '@(storeLocation)checkout/OpcSaveShipping/');
-                                if ($("#shipping-address-select").length > 0) {
-                                    Shipping.newAddress($('#shipping-address-select').val(), @Model.CheckoutModel.BillingAddress.BillingNewAddress.Id);
-                                }
-                            </script>
-                            <div class="buttons" id="shipping-buttons-container">
-                                @if (!Model.CheckoutModel.DisableBillingAddressCheckoutStep)
-                                {
-                                    <p class="back-link">
-                                        <a href="#" onclick="Checkout.back(); return false; "><small>&laquo; </small>@T("Common.Back")</a>
-                                    </p>
-                                }
-                                <span id="edit-shipping-address-buttons">
-                                    <button id="save-shipping-address-button" type="button" class="button-1" style="display: none" onclick="Shipping.saveEditAddress('@(storeLocation)checkout/SaveEditShippingAddress/'); return false;">@T("Common.Save")</button>
-                                </span>
-                                <button type="button" class="button-1 new-address-next-step-button" onclick="Shipping.save()">@T("Common.Continue")</button>
-                                <span id="shipping-please-wait" class="please-wait" style="display: none;"> @T("Common.LoadingNextStep")</span>
+                        <div class="spc-section-content">
+                            @await Html.PartialAsync("~/Views/Checkout/OpcShippingAddress.cshtml", Model.DataModel.ShippingAddress)
+                        </div>
+                    </div>
+
+                    @if (Model.Settings.ShowEstimateShipping)
+                    {
+                        <div class="spc-section spc-estimate-shipping">
+                            <div class="spc-section-title">
+                                <h2>@T("ShoppingCart.EstimateShipping")</h2>
+                            </div>
+                            <div class="spc-section-content">
+                                @await Component.InvokeAsync("ShoppingCartEstimateShipping", new { cart = Model.ShoppingCartModel.Items })
                             </div>
                         </div>
-                    </li>
-                    <li id="opc-shipping_method" class="tab-section">
-                        <div class="step-title">
-                            <span class="number">@shippingMethodStepNumber</span>
-                            <h2 class="title">@T("Checkout.ShippingMethod")</h2>
-                        </div>
-                        <div id="checkout-step-shipping-method" class="step a-item" style="display: none;">
-                            <form id="co-shipping-method-form" action="" method="post">
-                                <div id="checkout-shipping-method-load">
-                                    @*shipping methods content will be loaded here*@
-                                </div>
-                                <script asp-location="Footer">
-                                    var localized_data = {
-                                        NotAvailableMethodsError: "@T("ShippingMethod.NotAvailableMethodsError")",
-                                        SpecifyMethodError: "@T("ShippingMethod.SpecifyMethodError")"
-                                    };
-                                    ShippingMethod.init('#co-shipping-method-form', '@(storeLocation)checkout/OpcSaveShippingMethod/', localized_data);
-                                </script>
-                                <div class="buttons" id="shipping-method-buttons-container">
-                                    <p class="back-link">
-                                        <a href="#" onclick="Checkout.back(); return false;"><small>&laquo; </small>@T("Common.Back")</a>
-                                    </p>
-                                    <button type="button" class="button-1 shipping-method-next-step-button" onclick="ShippingMethod.save()">@T("Common.Continue")</button>
-                                    <span id="shipping-method-please-wait" class="please-wait" style="display: none;">@T("Common.LoadingNextStep")</span>
-                                </div>
-                            </form>
-                        </div>
-                    </li>
+                    }
                 }
-                <li id="opc-payment_method" class="tab-section">
-                    <div class="step-title">
-                        <span class="number">@paymentMethodStepNumber</span>
-                        <h2 class="title">@T("Checkout.PaymentMethod")</h2>
-                    </div>
-                    <div id="checkout-step-payment-method" class="step a-item" style="display: none;">
-                        <form action="" id="co-payment-method-form" method="post">
-                            <div id="checkout-payment-method-load">
-                                @*payment methods content will be loaded here*@ Payment is not required
-                            </div>
-                        </form>
-                        <script asp-location="Footer">
-                            var localized_data = {
-                                NotAvailableMethodsError: "@T("PaymentMethod.NotAvailableMethodsError")",
-                                SpecifyMethodError: "@T("PaymentMethod.SpecifyMethodError")"
-                            };
-                            PaymentMethod.init('#co-payment-method-form', '@(storeLocation)checkout/OpcSavePaymentMethod/', localized_data);
-                        </script>
-                        <div class="buttons" id="payment-method-buttons-container">
-                            <p class="back-link">
-                                <a href="#" onclick="Checkout.back(); return false;"><small>&laquo; </small>@T("Common.Back")</a>
-                            </p>
-                            <button type="button" name="save" class="button-1 payment-method-next-step-button" onclick="PaymentMethod.save()">@T("Common.Continue")</button>
-                            <span class="please-wait" id="payment-method-please-wait" style="display: none;">@T("Common.LoadingNextStep")</span>
-                        </div>
-                    </div>
-                </li>
-                <li id="opc-payment_info" class="tab-section">
-                    <div class="step-title">
-                        <span class="number">@paymentInfoStepNumber</span>
-                        <h2 class="title">@T("Checkout.PaymentInfo")</h2>
-                    </div>
-                    <div id="checkout-step-payment-info" class="step a-item" style="display: none;">
-                        <form action="" id="co-payment-info-form" method="post">
-                            <div id="checkout-payment-info-load">
-                                @*payment info content will be loaded here*@ Payment is not required
-                            </div>
-                        </form>
-                        <script asp-location="Footer">
-                            PaymentInfo.init('#co-payment-info-form', '@(storeLocation)checkout/OpcSavePaymentInfo/');
-                        </script>
-                        <div class="buttons" id="payment-info-buttons-container">
-                            <p class="back-link">
-                                <a href="#" onclick="Checkout.back(); return false;"><small>&laquo; </small>@T("Common.Back")</a>
-                            </p>
-                            <button type="button" class="button-1 payment-info-next-step-button" onclick="PaymentInfo.save()">@T("Common.Continue")</button>
-                            <span class="please-wait" id="payment-info-please-wait" style="display: none;">@T("Common.LoadingNextStep")</span>
-                        </div>
-                    </div>
-                </li>
-                <li id="opc-confirm_order" class="tab-section">
-                    <div class="step-title">
-                        <span class="number">@confirmOrderStepNumber</span>
-                        <h2 class="title">@T("Checkout.ConfirmOrder")</h2>
-                    </div>
-                    <div id="checkout-step-confirm-order" class="step a-item" style="display: none;">
-                        <div id="checkout-confirm-order-load">
-                            @*confirm order content will be loaded here*@
-                        </div>
-                        <script asp-location="Footer">
-                            ConfirmOrder.init('@(storeLocation)checkout/OpcConfirmOrder/', '@Url.RouteUrl("CheckoutCompleted")', @Model.CheckoutModel.DisplayCaptcha.ToString().ToLowerInvariant(), @Model.CheckoutModel.IsReCaptchaV3.ToString().ToLowerInvariant(), '@Model.CheckoutModel.ReCaptchaPublicKey', '#checkout-step-confirm-order');
-                        </script>
-                        <div class="buttons" id="confirm-order-buttons-container">
-                            <p class="back-link">
-                                <a href="#" onclick="Checkout.back(); return false;"><small>&laquo; </small>@T("Common.Back")</a>
-                            </p>
-                            <button type="button" class="button-1 confirm-order-next-step-button" onclick="ConfirmOrder.save()">@T("Checkout.ConfirmButton")</button>
-                            <span class="please-wait" id="confirm-order-please-wait" style="display: none;">@T("Checkout.SubmittingOrder")</span>
-                        </div>
-                    </div>
-                </li>
-            </ol>
-            @await Component.InvokeAsync("Widget", new { widgetZone = Nop.Web.Framework.Infrastructure.PublicWidgetZones.OpcContentAfter, additionalData = Model.CheckoutModel })
-        </div>
+            </div>
 
-        <div class="spc-sidebar-column" id="spc-sidebar-container">
-            @await Html.PartialAsync("~/Plugins/Misc.SinglePageCheckout/Views/_Sidebar.cshtml", Model)
-        </div>
+            <div class="spc-right-column">
 
+                <!-- Shipping Method -->
+                @if (Model.DataModel.ShippingRequired)
+                {
+                    <div class="spc-section spc-shipping-method">
+                        <div class="spc-section-title">
+                            <h2>@T("Checkout.ShippingMethod")</h2>
+                        </div>
+                        <div class="spc-section-content" id="spc-shipping-method-container">
+                            @await Html.PartialAsync("~/Plugins/Misc.SinglePageCheckout/Views/_ShippingMethods.cshtml", Model.DataModel.ShippingMethod)
+                        </div>
+                    </div>
+                }
+
+                <!-- Payment Method -->
+                <div class="spc-section spc-payment-method">
+                    <div class="spc-section-title">
+                        <h2>@T("Checkout.PaymentMethod")</h2>
+                    </div>
+                    <div class="spc-section-content" id="spc-payment-method-container">
+                        @await Html.PartialAsync("~/Plugins/Misc.SinglePageCheckout/Views/_PaymentMethods.cshtml", Model.DataModel.PaymentMethod)
+                    </div>
+                    <div class="spc-section-content" id="spc-payment-info-container">
+                        @await Html.PartialAsync("~/Plugins/Misc.SinglePageCheckout/Views/_PaymentInfo.cshtml", Model.DataModel.PaymentInfo)
+                    </div>
+                </div>
+
+                <!-- Product Grid (Cart Summary) -->
+                @if (Model.Settings.ShowCartOnCheckout)
+                {
+                    <div class="spc-section spc-cart-summary">
+                        <div class="spc-section-content" id="spc-cart-summary-container">
+                            @await Html.PartialAsync("~/Plugins/Misc.SinglePageCheckout/Views/_CartSummary.cshtml", Model.ShoppingCartModel)
+                        </div>
+                    </div>
+                }
+
+                <!-- Discount and Gift Card -->
+                <div class="spc-section spc-discounts-giftcards">
+                    <div class="spc-section-content">
+                        @await Html.PartialAsync("~/Plugins/Misc.SinglePageCheckout/Views/_DiscountBox.cshtml", Model.ShoppingCartModel)
+                    </div>
+                </div>
+
+                <!-- Order Totals -->
+                <div class="spc-section spc-order-totals">
+                    <div class="spc-section-title">
+                        <h2>@T("ShoppingCart.Totals")</h2>
+                    </div>
+                    <div class="spc-section-content" id="spc-order-totals-container">
+                        @await Html.PartialAsync("~/Plugins/Misc.SinglePageCheckout/Views/_OrderTotals.cshtml", Model.DataModel.OrderTotals)
+                    </div>
+                </div>
+
+                <!-- Confirm Button -->
+                <div class="spc-section spc-confirm-button">
+                    <button type="button" id="spc-confirm-order-button" class="button-1 confirm-order-button">@T("Checkout.ConfirmButton")</button>
+                    <div id="spc-errors-container" class="message-error" style="display: none; margin-top: 10px;"></div>
+                </div>
+
+            </div>
+        </form>
     </div>
-    <script asp-location="Footer">
-        Accordion.init('checkout-steps', '.step-title', true);
-        Accordion.openSection('#opc-billing');
-        Checkout.init('@(storeLocation)cart/');
-        if (Billing.disableBillingAddressCheckoutStep)
-        {
-            Accordion.hideSection('#opc-billing');
-            Billing.save();
-        }
-
-        if (window.SinglePageCheckoutSidebar) {
-            SinglePageCheckoutSidebar.init('@Url.RouteUrl(SinglePageCheckoutDefaults.SummaryRouteName)');
-        }
-    </script>
 </div>
+
+<script asp-location="Footer">
+    $(document).ready(function () {
+        if (typeof SinglePageCheckoutTwoColumns !== 'undefined') {
+            SinglePageCheckoutTwoColumns.init({
+                updateStateUrl: '@Url.Action("UpdateState", "SinglePageCheckout")',
+                confirmOrderUrl: '@Url.Action("ConfirmOrder", "SinglePageCheckout")',
+                updateCartUrl: '@Url.Action("UpdateCart", "ShoppingCart")'
+            });
+        }
+    });
+</script>


### PR DESCRIPTION
Transforms the Single Page Checkout into a clean, side-by-side two-column layout. Implements custom backend AJAX endpoints (`UpdateState` and `ConfirmOrder`) to allow dynamic recalculations of taxes, totals, and shipping methods without full page reloads or sequential wizard stepping.

---
*PR created automatically by Jules for task [10889366067296481267](https://jules.google.com/task/10889366067296481267) started by @sateeshmunagala*