### PR TITLE
Harden AIInterview runtime local media without Agora

### DIFF
--- a/src/Plugins/Nop.Plugin.Misc.AIInterview.Tests/RuntimeAndAdminTests.cs
+++ b/src/Plugins/Nop.Plugin.Misc.AIInterview.Tests/RuntimeAndAdminTests.cs
@@ -367,14 +367,26 @@ public class RuntimeAndAdminTests
     }
 
     [Test]
-    public void RuntimeView_Contains_Recording_Upload_And_Agora_Renewal_Hooks()
+    public void RuntimeView_Contains_Recording_And_Upload_Hooks()
     {
         var runtimeViewText = System.IO.File.ReadAllText(TestFilePathHelper.GetPluginFilePath("Views", "MockAiInterview", "Runtime.cshtml"));
 
         Assert.That(runtimeViewText, Does.Contain("recordingUploadUrl"));
         Assert.That(runtimeViewText, Does.Contain("MediaRecorder"));
         Assert.That(runtimeViewText, Does.Contain("toggle-recording"));
-                                Assert.That(runtimeViewText, Does.Contain("uploadRecording"));
+        Assert.That(runtimeViewText, Does.Contain("uploadRecording"));
+        Assert.That(runtimeViewText, Does.Contain("getUserMedia"));
+        Assert.That(runtimeViewText, Does.Contain("SpeechSDK"));
+        Assert.That(runtimeViewText, Does.Contain("speechTokenUrl"));
+        Assert.That(runtimeViewText, Does.Contain("submitAnswer"));
+        Assert.That(runtimeViewText, Does.Contain("stopInterview"));
+
+        Assert.That(runtimeViewText, Does.Not.Contain("AgoraRTC"));
+        Assert.That(runtimeViewText, Does.Not.Contain("download.agora.io"));
+        Assert.That(runtimeViewText, Does.Not.Contain("ensureAgoraSession"));
+        Assert.That(runtimeViewText, Does.Not.Contain("renewAgoraToken"));
+        Assert.That(runtimeViewText, Does.Not.Contain("leaveAgoraSession"));
+        Assert.That(runtimeViewText, Does.Not.Contain("agora-token"));
     }
 
     [Test]

--- a/src/Plugins/Nop.Plugin.Misc.AIInterview/Views/MockAiInterview/Runtime.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.AIInterview/Views/MockAiInterview/Runtime.cshtml
@@ -156,7 +156,7 @@
         let speechRecognizer = null;
         let speechSdkLoading = null;
         let speechSdkLoaded = false;
-                                                                let mediaRecorder = null;
+        let mediaRecorder = null;
         let recordingChunks = [];
         let recordingMimeType = 'video/webm';
         let recordingEnabled = false;
@@ -227,6 +227,12 @@
             analyser = null;
             meterFrame && cancelAnimationFrame(meterFrame);
             meterFrame = null;
+            video.srcObject = null;
+            video.style.display = 'none';
+            cameraPlaceholder.style.display = '';
+            document.getElementById('toggle-camera').textContent = 'Camera On';
+            document.getElementById('toggle-mic').textContent = 'Mic On';
+            audioMeter.forEach(bar => { bar.style.height = '8px'; bar.style.background = '#cbd5e1'; });
             await stopSpeechRecognition();
             questionBox.textContent = completionText;
             messageBox.textContent = result.feedback || result.message || '';
@@ -636,11 +642,6 @@
                 return;
             }
         };
-
-
-
-
-
 
         const setCamera = async (enabled, skipRecordingSync = false) => {
             if (!navigator.mediaDevices?.getUserMedia) {


### PR DESCRIPTION
This hardens the initial Agora deletion pass for the AI Interview Plugin's runtime page. The browser no longer requests Agora components and local MediaRecorder successfully handles streams and cleans up on completion. Tests assert the Agora browser tokens/SDKs are omitted while keeping assertions for required Media Recorder and UI items.

---
*PR created automatically by Jules for task [7955933820722932116](https://jules.google.com/task/7955933820722932116) started by @sateeshmunagala*