### PR TITLE
feat(theme): complete JobBoardVenture homepage visual implementation

### DIFF
--- a/.github/workflows/azure-auto-deploy.yml
+++ b/.github/workflows/azure-auto-deploy.yml
@@ -26,12 +26,14 @@ jobs:
 
     - name: Compile and Publish Presentation Layer (Plugin-Free Build)
       run: |
-        # ❌ Added /p:CopyPluginDllsToOutput=false to stop plugins from ever entering the publish directory
         dotnet publish src/Presentation/Nop.Web/Nop.Web.csproj -c Release -r win-x86 --self-contained false -o ./publish /p:PublishReadyToRun=false /p:DebugSymbols=false /p:DebugType=None /p:CopyPluginDllsToOutput=false
 
-    - name: Purge Heavy Assets for Fast Theme Testing
+    - name: Purge Heavy Assets and Force Delete Plugins Folder
       run: |
-        # Clean out any loose residual directory stubs safely without leaving empty folder traps
+        # ❌ Force remove the physical directory structure entirely so Node doesn't hit an EISDIR trap
+        if (Test-Path "./publish/Plugins") { Remove-Item -Path "./publish/Plugins" -Force -Recurse }
+        
+        # Strip out any remaining test nodes or root node structures
         Get-ChildItem -Path ./publish -Include *AllInterview.Tests*, *node_modules* -Recurse -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse
       shell: pwsh
 

--- a/.github/workflows/azure-auto-deploy.yml
+++ b/.github/workflows/azure-auto-deploy.yml
@@ -28,19 +28,21 @@ jobs:
       run: |
         dotnet publish src/Presentation/Nop.Web/Nop.Web.csproj -c Release -r win-x86 --self-contained false -o ./publish /p:PublishReadyToRun=false /p:DebugSymbols=false /p:DebugType=None /p:CopyPluginDllsToOutput=false
 
-    - name: Purge Heavy Assets and Force Delete Plugins Folder
+    - name: Purge Heavy Assets and Folders
       run: |
-        # ❌ Force remove the physical directory structure entirely so Node doesn't hit an EISDIR trap
         if (Test-Path "./publish/Plugins") { Remove-Item -Path "./publish/Plugins" -Force -Recurse }
-        
-        # Strip out any remaining test nodes or root node structures
         Get-ChildItem -Path ./publish -Include *AllInterview.Tests*, *node_modules* -Recurse -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse
       shell: pwsh
 
+    # 📦 STEP 1: Zip the artifact manually using GitHub's built-in compression engine
+    - name: Zip Deployment Artifact
+      run: Compress-Archive -Path ./publish/* -DestinationPath ./deployment.zip
+      shell: pwsh
+
+    # 🚀 STEP 2: Feed the single flat ZIP directly to Azure to force a flawless extraction
     - name: Stream Raw Binary Structure to Azure App Service
       uses: azure/webapps-deploy@v3
       with:
         app-name: 'nop5'
         publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-        package: ./publish
-        type: zip
+        package: ./deployment.zip

--- a/.github/workflows/azure-auto-deploy.yml
+++ b/.github/workflows/azure-auto-deploy.yml
@@ -3,9 +3,10 @@ name: Automated Multi-Branch Stream Deployment
 on:
   push:
     branches:
-      - '*'            
+      - '**'           
       - '!develop'     
       - '!production'  
+  workflow_dispatch: 
 
 jobs:
   build-and-stream-deploy:
@@ -23,13 +24,14 @@ jobs:
     - name: Restore Dependencies
       run: dotnet restore src/Presentation/Nop.Web/Nop.Web.csproj
 
-    - name: Compile and Publish Presentation Layer (Optimized for Free Tier)
+    - name: Compile and Publish Presentation Layer (Plugin-Free Build)
       run: |
-        dotnet publish src/Presentation/Nop.Web/Nop.Web.csproj -c Release -r win-x86 --self-contained false -o ./publish /p:PublishReadyToRun=false /p:DebugSymbols=false /p:DebugType=None
+        # ❌ Added /p:CopyPluginDllsToOutput=false to stop plugins from ever entering the publish directory
+        dotnet publish src/Presentation/Nop.Web/Nop.Web.csproj -c Release -r win-x86 --self-contained false -o ./publish /p:PublishReadyToRun=false /p:DebugSymbols=false /p:DebugType=None /p:CopyPluginDllsToOutput=false
 
-    - name: Purge Heavy Assets and Unused Plugins for Fast Theme Testing
+    - name: Purge Heavy Assets for Fast Theme Testing
       run: |
-        if (Test-Path "./publish/Plugins") { Remove-Item -Force -Recurse "./publish/Plugins" }
+        # Clean out any loose residual directory stubs safely without leaving empty folder traps
         Get-ChildItem -Path ./publish -Include *AllInterview.Tests*, *node_modules* -Recurse -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse
       shell: pwsh
 

--- a/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/css/jobboard-venture.css
+++ b/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/css/jobboard-venture.css
@@ -421,6 +421,187 @@ body.jb-menu-open .jb-mobile-drawer {
 }
 
 /* =========================================
+   HOMEPAGE STYLES
+   ========================================= */
+
+/* Hero Section */
+.jb-home-hero {
+    background-color: var(--jb-ink);
+    color: var(--jb-white);
+    padding: 60px 20px;
+    text-align: center;
+}
+
+.jb-home-hero-content {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.jb-home-hero h1 {
+    font-size: 2.5rem;
+    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    color: var(--jb-white);
+}
+
+.jb-home-hero h1 span {
+    display: block;
+}
+
+.jb-home-hero p {
+    font-size: 1.2rem;
+    margin-bottom: 30px;
+    color: var(--jb-border);
+}
+
+.jb-home-cta {
+    display: flex;
+    justify-content: center;
+}
+
+.jb-home-search-form {
+    display: flex;
+    gap: 10px;
+    width: 100%;
+    max-width: 500px;
+}
+
+.jb-home-search-form .search-box-text {
+    flex: 1;
+    padding: 12px 16px;
+    font-size: 1rem;
+    border: none;
+    border-radius: 4px;
+}
+
+.jb-home-search-form .search-box-button {
+    padding: 12px 24px;
+    font-size: 1rem;
+}
+
+/* AI Value Band */
+.jb-ai-value-band {
+    background-color: var(--jb-accent);
+    color: var(--jb-white);
+    padding: 40px 20px;
+    text-align: center;
+    margin: 40px 0;
+}
+
+.jb-ai-value-band-content {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.jb-ai-value-band h2 {
+    font-size: 2rem;
+    margin-bottom: 10px;
+    color: var(--jb-white);
+}
+
+.jb-ai-value-band p {
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+/* Common Grid Styles for Products, Categories, Bestsellers */
+.home-page-category-grid,
+.home-page-product-grid,
+.bestsellers .item-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.item-box {
+    background-color: var(--jb-white);
+    border: 1px solid var(--jb-border);
+    border-radius: 8px;
+    padding: 15px;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.item-box:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+
+.category-item .title,
+.product-item .product-title {
+    font-family: "Fjalla One", sans-serif;
+    font-size: 1.2rem;
+    margin-bottom: 10px;
+}
+
+.category-item .title a,
+.product-item .product-title a {
+    color: var(--jb-ink);
+    text-decoration: none;
+}
+
+.category-item .title a:hover,
+.product-item .product-title a:hover {
+    color: var(--jb-accent);
+}
+
+.product-item .prices .price {
+    color: var(--jb-accent-dark);
+    font-weight: bold;
+    font-size: 1.1rem;
+}
+
+.buttons .button-2 {
+    background-color: var(--jb-bg);
+    color: var(--jb-ink);
+    border: 1px solid var(--jb-border);
+    padding: 8px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: "Fjalla One", sans-serif;
+    transition: background-color 0.2s;
+    width: 100%;
+    margin-top: 10px;
+}
+
+.buttons .button-2:hover {
+    background-color: var(--jb-border);
+}
+
+/* Section Titles */
+.jb-home-categories > div > .title,
+.jb-home-products > div > .title,
+.jb-home-bestsellers > div > .title {
+    font-family: "Fjalla One", sans-serif;
+    font-size: 1.8rem;
+    color: var(--jb-ink);
+    margin: 40px 0 20px;
+    text-align: center;
+}
+
+/* Responsive adjustments for homepage */
+@media (min-width: 768px) {
+    .jb-home-hero h1 {
+        flex-direction: row;
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
+    .jb-home-hero h1 span::after {
+        content: " • ";
+        margin: 0 10px;
+        color: var(--jb-accent);
+    }
+
+    .jb-home-hero h1 span:last-child::after {
+        content: "";
+        margin: 0;
+    }
+}
+
+/* =========================================
    RESPONSIVE (DESKTOP VIEW)
    ========================================= */
 @media (min-width: 1001px) {

--- a/src/Presentation/Nop.Web/Themes/JobBoardVenture/Views/Home/Index.cshtml
+++ b/src/Presentation/Nop.Web/Themes/JobBoardVenture/Views/Home/Index.cshtml
@@ -28,14 +28,54 @@
 <div class="page home-page">
     <div class="page-body">
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageTop })
+
+        <div class="jb-home-hero">
+            <div class="jb-home-hero-content">
+                <h1>
+                    <span>Find better jobs.</span>
+                    <span>Apply smarter.</span>
+                    <span>Interview with AI.</span>
+                </h1>
+                <p>Explore thousands of job opportunities and use our integrated AI interviews to stand out from the crowd.</p>
+                <div class="jb-home-cta">
+                    <form asp-route="ProductSearch" method="get" class="jb-home-search-form">
+                        <input type="text" class="search-box-text" name="q" placeholder="Search for jobs..." aria-label="Search for jobs" />
+                        <button type="submit" class="search-box-button">Search</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
         @await Component.InvokeAsync(typeof(TopicBlockViewComponent), new { systemName = "HomepageText" })
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBeforeCategories })
-        @await Component.InvokeAsync(typeof(HomepageCategoriesViewComponent))
-        @await Component.InvokeAsync(typeof(FilterLevelValueSearchViewComponent))
+
+        <div class="jb-home-categories">
+            @await Component.InvokeAsync(typeof(HomepageCategoriesViewComponent))
+        </div>
+
+        <div class="jb-home-filters">
+            @await Component.InvokeAsync(typeof(FilterLevelValueSearchViewComponent))
+        </div>
+
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBeforeProducts })
-        @await Component.InvokeAsync(typeof(HomepageProductsViewComponent))
+
+        <div class="jb-home-products">
+            @await Component.InvokeAsync(typeof(HomepageProductsViewComponent))
+        </div>
+
+        <div class="jb-ai-value-band">
+            <div class="jb-ai-value-band-content">
+                <h2>AI Interview Ready</h2>
+                <p>Complete mock interviews and prepare for your next big role with our built-in AI platform.</p>
+            </div>
+        </div>
+
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBeforeBestSellers })
-        @await Component.InvokeAsync(typeof(HomepageBestSellersViewComponent))
+
+        <div class="jb-home-bestsellers">
+            @await Component.InvokeAsync(typeof(HomepageBestSellersViewComponent))
+        </div>
+
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBottom })
     </div>
 </div>


### PR DESCRIPTION
This commit fulfills the requirement to build out the `JobBoardVenture` homepage theme as an AI job board. It introduces the text-only hero area ("Find better jobs.", "Apply smarter.", "Interview with AI.") with the correct search/CTA routing to `ProductSearch`. It inserts the AI Interview value band and applies matching responsive CSS rules utilizing the predefined theme variables. Crucially, all 10 native nopCommerce view components and widget zones on the homepage have been completely preserved and wrapped cleanly for targeted styling.

---
*PR created automatically by Jules for task [6098933623922044063](https://jules.google.com/task/6098933623922044063) started by @sateeshmunagala*