### PR TITLE
Fix JobBoardVenture visual reset gaps (mobile drawer, footer, UI)

### DIFF
--- a/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/css/jobboard-venture.css
+++ b/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/css/jobboard-venture.css
@@ -1207,3 +1207,170 @@ body.jb-menu-open .jb-mobile-drawer {
 .html-search-page .block .listbox ul {
     padding-left: 0;
 }
+
+/* Force mobile drawer visibility when open */
+body.jb-menu-open #jb-mobile-menu-drawer {
+    left: 0 !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    display: flex !important;
+}
+
+body.jb-menu-open .jb-drawer-overlay {
+    visibility: visible !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+}
+
+body.jb-search-open #jb-mobile-search-overlay {
+    display: flex !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+}
+
+/* Hide the inner "Categories" toggle text so top-level links are usable without double clicking */
+#jb-mobile-menu-drawer .menu-toggle {
+    display: none !important;
+}
+#jb-mobile-menu-drawer .menu {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    position: relative !important;
+    top: 0 !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+}
+
+/* Override default footer navigation styles */
+.footer-navigation {
+    background-color: transparent !important;
+    color: var(--jb-muted) !important;
+}
+
+.footer-menu {
+    background-color: transparent !important;
+    border: none !important;
+    margin-bottom: 20px !important;
+}
+
+.footer-menu-title, .footer-menu-toggle, .footer-menu__title, .footer-menu__toggle {
+    background-color: transparent !important;
+    color: var(--jb-ink) !important;
+    font-family: "Fjalla One", sans-serif !important;
+    font-size: 1.2rem !important;
+    padding: 0 0 10px 0 !important;
+    border-bottom: none !important;
+}
+
+.footer-menu-title::after, .footer-menu-toggle::after, .footer-menu__title::after, .footer-menu__toggle::after {
+    display: none !important;
+}
+
+.footer-menu-list, .footer-menu__list {
+    display: block !important;
+    padding: 0 !important;
+    background-color: transparent !important;
+    border: none !important;
+}
+
+.footer-menu-list .footer-menu-item a,
+.footer-menu-list .footer-menu-link,
+.footer-menu__list .footer-menu__item a {
+    color: var(--jb-muted) !important;
+    font-family: "Lato", sans-serif !important;
+    padding: 5px 0 !important;
+    display: block !important;
+    text-decoration: none !important;
+}
+
+.footer-menu-list .footer-menu-item a:hover,
+.footer-menu-list .footer-menu-link:hover,
+.footer-menu__list .footer-menu__item a:hover {
+    color: var(--jb-accent) !important;
+}
+
+#jb-mobile-menu-drawer .menu__toggle {
+    display: none !important;
+}
+
+@media (max-width: 1000px) {
+    .footer-upper {
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+    }
+    .footer-navigation {
+        display: flex;
+        flex-direction: column;
+        gap: 15px;
+    }
+    .footer-menu {
+        margin-bottom: 0 !important;
+    }
+    .footer-block.follow-us {
+        margin-top: 20px;
+    }
+}
+
+/* Fix Mobile Listing Cards & Filters */
+@media (max-width: 600px) {
+    .html-category-page .item-grid,
+    .html-search-page .item-grid {
+        display: block !important;
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+
+    .html-category-page .item-box,
+    .html-search-page .item-box {
+        width: 100% !important;
+        margin: 0 0 20px 0 !important;
+        padding: 0 !important;
+    }
+
+    .html-category-page .product-item .buttons,
+    .html-search-page .product-item .buttons {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+
+    /* Primary buttons get full width on mobile */
+    .html-category-page .product-item .buttons .product-box-add-to-cart-button,
+    .html-search-page .product-item .buttons .product-box-add-to-cart-button,
+    .html-category-page .product-item .buttons button[value="Apply"],
+    .html-search-page .product-item .buttons button[value="Apply"] {
+        width: 100% !important;
+        order: 1;
+    }
+
+    /* Secondary buttons (compare, wishlist) share the row and are compact */
+    .html-category-page .product-item .buttons .add-to-compare-list-button,
+    .html-search-page .product-item .buttons .add-to-compare-list-button,
+    .html-category-page .product-item .buttons .add-to-wishlist-button,
+    .html-search-page .product-item .buttons .add-to-wishlist-button {
+        flex: 1;
+        width: auto !important;
+        order: 2;
+        padding: 8px !important;
+        font-size: 0.9rem !important;
+        background-color: transparent !important;
+        border: 1px solid var(--jb-border) !important;
+        color: var(--jb-muted) !important;
+    }
+
+    /* Keep filters compact on mobile */
+    .html-category-page .block,
+    .html-search-page .block {
+        margin-bottom: 20px;
+    }
+
+    .html-category-page .product-selectors,
+    .html-search-page .product-selectors {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+}

--- a/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/js/jobboard-venture.js
+++ b/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/js/jobboard-venture.js
@@ -41,29 +41,54 @@
         var menuClose = document.querySelector('.jb-drawer-close');
         var drawerOverlay = document.querySelector('.jb-drawer-overlay');
 
-        function openMenu() {
+        function openMenu(e) {
+            if (e) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+            if (document.body.classList.contains('jb-menu-open')) {
+                closeMenu(e);
+                return;
+            }
             document.body.classList.add('jb-menu-open');
             if (menuToggle) menuToggle.setAttribute('aria-expanded', 'true');
         }
 
-        function closeMenu() {
+        function closeMenu(e) {
+            if (e) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
             document.body.classList.remove('jb-menu-open');
             if (menuToggle) menuToggle.setAttribute('aria-expanded', 'false');
         }
 
-        if (menuToggle) {
-            menuToggle.addEventListener('click', openMenu);
+        function handlePointerOrClick(element, handler) {
+            if (!element) return;
+            element.addEventListener('click', handler);
+            element.addEventListener('touchstart', function(e) {
+                e.preventDefault();
+                handler(e);
+            }, { passive: false });
         }
-        if (menuClose) {
-            menuClose.addEventListener('click', closeMenu);
-        }
+
+        handlePointerOrClick(menuToggle, openMenu);
+        handlePointerOrClick(menuClose, closeMenu);
 
         // --- MOBILE SEARCH OVERLAY ---
         var searchToggle = document.querySelector('.jb-search-toggle');
         var searchClose = document.querySelector('.jb-search-close');
         var searchInput = document.querySelector('.jb-search-overlay .search-box-text');
 
-        function openSearch() {
+        function openSearch(e) {
+            if (e) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+            if (document.body.classList.contains('jb-search-open')) {
+                closeSearch(e);
+                return;
+            }
             document.body.classList.add('jb-search-open');
             if (searchToggle) searchToggle.setAttribute('aria-expanded', 'true');
             if (searchInput) {
@@ -72,17 +97,17 @@
             }
         }
 
-        function closeSearch() {
+        function closeSearch(e) {
+            if (e) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
             document.body.classList.remove('jb-search-open');
             if (searchToggle) searchToggle.setAttribute('aria-expanded', 'false');
         }
 
-        if (searchToggle) {
-            searchToggle.addEventListener('click', openSearch);
-        }
-        if (searchClose) {
-            searchClose.addEventListener('click', closeSearch);
-        }
+        handlePointerOrClick(searchToggle, openSearch);
+        handlePointerOrClick(searchClose, closeSearch);
 
         if (drawerOverlay) {
             drawerOverlay.addEventListener('click', function() {

--- a/src/Presentation/Nop.Web/Themes/JobBoardVenture/Views/Home/Index.cshtml
+++ b/src/Presentation/Nop.Web/Themes/JobBoardVenture/Views/Home/Index.cshtml
@@ -60,6 +60,12 @@
             </div>
         </div>
 
+        <div class="jb-home-native-components" style="opacity: 0.8; padding-top: 40px; border-top: 1px solid var(--jb-border);">
+            @await Component.InvokeAsync(typeof(HomepageCategoriesViewComponent))
+            @await Component.InvokeAsync(typeof(HomepageProductsViewComponent))
+            @await Component.InvokeAsync(typeof(HomepageBestSellersViewComponent))
+        </div>
+
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBottom })
     </div>
 </div>


### PR DESCRIPTION
This branch completes the visual-quality reset gaps for the `JobBoardVenture` theme.

**Changes included:**
*   **Mobile Drawer:** Updated `jobboard-venture.js` and `jobboard-venture.css` to properly initialize touch/click listeners without double-toggling and apply `!important` visibility states so the drawer physically displays on the left instead of remaining hidden. Hid the inner "Categories" toggle so top-level links are accessible without double clicks.
*   **Footer Navigation:** Added mobile-specific CSS overrides for `.footer-menu` and `.footer-navigation` elements. Replaced standard nopCommerce blue styling with transparent backgrounds, muted text, and Fjalla headings.
*   **Listing Layout:** Fixed `.item-box` and `.item-grid` padding/margin styling for mobile so job cards stretch full-width in a single column instead of scrunching up. Adjusted secondary `.buttons` (compare/wishlist) to share a row instead of each demanding 100% width.
*   **Homepage Cleanup:** Restored native components (categories, products, bestsellers) to the bottom of the `JobBoardVenture` `Index.cshtml` in a subdued opacity block.

**Investigation Notes:**
Regarding the `ProductTemplate.JobDetails.cshtml` 500 error: Since the `src/Plugins/Nop.Plugin.Misc.AIInterview` source directory is completely missing from this checked-out state, and nopCommerce `ProductModelFactory` explicitly queries the `ProductTemplate` database table for its absolute ViewPath, we cannot just add a fallback to `Themes/.../Views/Product/`. If the DB has `~/Plugins/Misc.AIInterview/Views/ProductTemplate.JobDetails.cshtml`, the engine looks there, and without the plugin mounted, it fails. We cannot fix the deployment artifact via the theme without the DB context or plugin codebase.

---
*PR created automatically by Jules for task [12664405659574413861](https://jules.google.com/task/12664405659574413861) started by @sateeshmunagala*