### PR TITLE
Fix job-detail 500 block, restore homepage native hooks, and polish mobile UI

### DIFF
--- a/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/css/jobboard-venture.css
+++ b/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/css/jobboard-venture.css
@@ -1,9 +1,3 @@
-.jb-home-native-components {
-    opacity: 0.8;
-    padding-top: 40px;
-    border-top: 1px solid var(--jb-border);
-}
-
 :root {
     --jb-bg: #f0f0f0;
     --jb-ink: #2c2c2c;
@@ -1054,6 +1048,12 @@ body.jb-menu-open .jb-mobile-drawer {
     transition: background-color 0.2s, color 0.2s;
 }
 
+.jb-home-native-components {
+    opacity: 0.8;
+    padding-top: 40px;
+    border-top: 1px solid var(--jb-border);
+}
+
 /* The Apply / View Button */
 .html-category-page .product-item .buttons .product-box-add-to-cart-button,
 .html-search-page .product-item .buttons .product-box-add-to-cart-button,
@@ -1281,14 +1281,11 @@ body.jb-search-open #jb-mobile-search-overlay {
 }
 
 @media (max-width: 1000px) {
-    .footer-menu-list, .footer-menu__list {
+    .footer-menu__list {
         display: none !important;
     }
 
-    .footer-block.footer-menu--active .footer-menu__list,
-    .footer-block.footer-menu--active .footer-menu-list,
-    .footer-block.jb-footer-open .footer-menu__list,
-    .footer-block.jb-footer-open .footer-menu-list {
+    .footer-menu.footer-menu--active .footer-menu__list {
         display: block !important;
     }
 }

--- a/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/js/jobboard-venture.js
+++ b/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/js/jobboard-venture.js
@@ -46,10 +46,7 @@
                 e.preventDefault();
                 e.stopPropagation();
             }
-            if (document.body.classList.contains('jb-menu-open')) {
-                closeMenu(e);
-                return;
-            }
+            if (document.body.classList.contains('jb-menu-open')) return;
             document.body.classList.add('jb-menu-open');
             if (menuToggle) menuToggle.setAttribute('aria-expanded', 'true');
         }
@@ -65,32 +62,25 @@
 
         function handlePointerOrClick(element, handler) {
             if (!element) return;
-            var isPointerSupported = window.PointerEvent ? true : false;
-
-            if (isPointerSupported) {
+            if (window.PointerEvent) {
                 element.addEventListener('pointerup', function (e) {
-                    // Ignore right-clicks
                     if (e.button === 2) return;
                     e.preventDefault();
                     handler(e);
                 });
             } else {
-                var lastToggleTime = 0;
-                var threshold = 300; // milliseconds
-
-                var safeHandler = function(e) {
-                    var now = Date.now();
-                    if (now - lastToggleTime > threshold) {
-                        lastToggleTime = now;
-                        handler(e);
-                    }
-                };
-
-                element.addEventListener('click', safeHandler);
+                var isTouch = false;
                 element.addEventListener('touchstart', function(e) {
+                    isTouch = true;
                     e.preventDefault();
-                    safeHandler(e);
+                    handler(e);
+                    setTimeout(function() { isTouch = false; }, 500);
                 }, { passive: false });
+                element.addEventListener('click', function(e) {
+                    if (isTouch) return;
+                    e.preventDefault();
+                    handler(e);
+                });
             }
         }
 
@@ -107,10 +97,7 @@
                 e.preventDefault();
                 e.stopPropagation();
             }
-            if (document.body.classList.contains('jb-search-open')) {
-                closeSearch(e);
-                return;
-            }
+            if (document.body.classList.contains('jb-search-open')) return;
             document.body.classList.add('jb-search-open');
             if (searchToggle) searchToggle.setAttribute('aria-expanded', 'true');
             if (searchInput) {


### PR DESCRIPTION
This submission addresses the remaining static gaps for the JobBoardVenture UI.

**Job-Detail 500 Error Blocked**
I investigated the job detail 500 error. The core fallback view `src/Presentation/Nop.Web/Views/Product/ProductTemplate.JobDetails.cshtml` is indeed present. However, because `src/Plugins/Nop.Plugin.Misc.AIInterview` has no valid view source files in this branch, if the deployed job products in the database are explicitly mapped to the plugin view path (e.g. `~/Plugins/Misc.AIInterview/Views/ProductTemplate.JobDetails.cshtml`), the framework will bypass the local fallback and throw a 500 error when it cannot find the plugin file. Since the scope strictly prohibits editing plugins or faking DB files, this view path misconfiguration is the exact blocker. 

**Homepage Restored Native Hooks without Inline Styles**
I applied the exact requested visually subdued styling (`opacity: 0.8; padding-top: 40px; border-top: 1px solid var(--jb-border);`) to the `.jb-home-native-components` class in `jobboard-venture.css`. I verified that `Index.cshtml` contains no inline `style=` attributes and correctly invokes `HomepageBeforeProducts` and `HomepageBeforeBestSellers` native widget zones.

**Mobile Footer Accordion Behavior**
I updated the CSS max-width 1000px query to target precisely `.footer-menu__list` (`display: none !important`) and `.footer-menu.footer-menu--active .footer-menu__list` (`display: block !important`). This ensures that the mobile columns are collapsed by default and correctly expand when the native mobile footer accordion script applies the active class, preserving Venture's custom typography styling without reintroducing default blue accordion bars.

**Mobile Drawer/Search Double Event Fix**
I addressed the touch/click double-toggle vulnerability on devices that fire both events. I updated `jobboard-venture.js` `handlePointerOrClick` function to track an `isTouch` flag for 500ms when `touchstart` fires, completely discarding subsequent `click` events during that window. I also fixed `openMenu` and `openSearch` to immediately return early if their respective `jb-menu-open` or `jb-search-open` classes are already present, rather than accidentally calling the `close` function.

**Validation Complete**
- `dotnet build --no-restore --configuration Release src/Presentation/Nop.Web/Nop.Web.csproj` succeeded.
- `dotnet test src/NopCommerce.sln` passed all tests.
- Static validations (`jobs.html` check, planner file checks, github workflows, plugins) were fully clean.

*Reminder: Deploy and perform live visual validation to ensure mobile behaviors are correct in the device.*

---
*PR created automatically by Jules for task [15207052548990639765](https://jules.google.com/task/15207052548990639765) started by @sateeshmunagala*