### PR TITLE
Tighten JobBoardVenture listing CTA and home retail content

### DIFF
--- a/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/css/jobboard-venture.css
+++ b/src/Presentation/Nop.Web/Themes/JobBoardVenture/Content/css/jobboard-venture.css
@@ -1063,11 +1063,22 @@ body.jb-menu-open .jb-mobile-drawer {
 .jb-home-native-components .picture,
 .jb-home-native-components .prices,
 .jb-home-native-components .buttons,
-.jb-home-native-components .product-rating-box {
+.jb-home-native-components .product-rating-box,
+.jb-home-native-components .sku,
+.jb-home-native-components .description,
+.jb-home-native-components .product-title {
     display: none !important;
 }
 
 /* The Apply / View Button */
+.jb-view-job-button { display: none; }
+.html-category-page .product-item .jb-view-job-button,
+.html-search-page .product-item .jb-view-job-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .html-category-page .product-item .buttons .product-box-add-to-cart-button,
 .html-search-page .product-item .buttons .product-box-add-to-cart-button,
 .html-category-page .product-item .buttons .button-2,
@@ -1083,23 +1094,10 @@ body.jb-menu-open .jb-mobile-drawer {
     background-color: var(--jb-accent-dark);
 }
 
-/* Change "Add to cart" text to "View Job" */
+/* Hide original Add to Cart button on listing pages to avoid duplicate actions since we have jb-view-job-button now */
 .html-category-page .product-item .buttons .product-box-add-to-cart-button,
 .html-search-page .product-item .buttons .product-box-add-to-cart-button {
-    color: transparent !important;
-    position: relative;
-}
-
-.html-category-page .product-item .buttons .product-box-add-to-cart-button::after,
-.html-search-page .product-item .buttons .product-box-add-to-cart-button::after {
-    content: "View Job";
-    color: var(--jb-white);
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 100%;
-    text-align: center;
+    display: none !important;
 }
 
 /* Secondary Buttons (Compare, Wishlist) */

--- a/src/Presentation/Nop.Web/Themes/JobBoardVenture/Views/Shared/_ProductBox.cshtml
+++ b/src/Presentation/Nop.Web/Themes/JobBoardVenture/Views/Shared/_ProductBox.cshtml
@@ -1,0 +1,143 @@
+﻿@model ProductOverviewModel
+
+@using Nop.Core
+@using Nop.Core.Domain.Catalog
+@using Nop.Core.Domain.Orders
+@using Nop.Core.Domain.Tax
+
+@inject CatalogSettings catalogSettings
+@inject IWorkContext workContext
+
+@{
+    //prepare "Add to cart" AJAX link
+    var addtocartlink = "";
+    var shoppingCartTypeId = (int)ShoppingCartType.ShoppingCart;
+    var quantity = 1;
+    if (Model.ProductPrice.ForceRedirectionAfterAddingToCart)
+    {
+        addtocartlink = Url.RouteUrl(NopRouteNames.Ajax.ADD_PRODUCT_TO_CART_CATALOG, new { productId = Model.Id, shoppingCartTypeId = shoppingCartTypeId, quantity = quantity, forceredirection = Model.ProductPrice.ForceRedirectionAfterAddingToCart });
+    }
+    else
+    {
+        addtocartlink = Url.RouteUrl(NopRouteNames.Ajax.ADD_PRODUCT_TO_CART_CATALOG, new { productId = Model.Id, shoppingCartTypeId = shoppingCartTypeId, quantity = quantity });
+    }
+
+    var addtowishlistlink = Url.RouteUrl(NopRouteNames.Ajax.ADD_PRODUCT_TO_CART_CATALOG, new { productId = Model.Id, shoppingCartTypeId = (int)ShoppingCartType.Wishlist, quantity = quantity });
+    var addtocomparelink = Url.RouteUrl(NopRouteNames.Ajax.ADD_PRODUCT_TO_COMPARE, new { productId = Model.Id });
+}
+<article class="product-item" data-productid="@Model.Id">
+    <div class="picture">
+        @if (Model.PictureModels.Count > 1)
+        {
+            <div class="swiper" id="swiper-@Model.Id" dir="@Html.GetUIDirection(!await Html.ShouldUseRtlThemeAsync())">
+                <div class="swiper-wrapper">
+                    @foreach (var picture in Model.PictureModels)
+                    {
+                        <a class="swiper-slide" href="@(await NopUrl.RouteGenericUrlAsync<Product>(new { SeName = Model.SeName }))" title="@picture.Title">
+                            <img alt="@picture.AlternateText" src="@picture.ImageUrl" title="@picture.Title" />
+                        </a>
+                    }
+                </div>
+                <!-- Add Pagination -->
+                <div class="swiper-pagination"></div>
+            </div>
+
+            <script asp-location="Footer">
+                new Swiper('#swiper-@(Model.Id)', {
+                    pagination: {
+                        clickable: true,
+                        el: '.swiper-pagination',
+                    },
+                });
+            </script>
+        }
+        else
+        {
+            var picture = Model.PictureModels.FirstOrDefault();
+            <a href="@(await NopUrl.RouteGenericUrlAsync<Product>(new { SeName = Model.SeName }))" title="@picture?.Title">
+                <img alt="@picture?.AlternateText" src="@picture?.ImageUrl" title="@picture?.Title" />
+            </a>
+        }
+    </div>
+    <div class="details">
+        <h2 class="product-title">
+            <a href="@(await NopUrl.RouteGenericUrlAsync<Product>(new {SeName = Model.SeName }))">@Model.Name</a>
+        </h2>
+        @if (catalogSettings.ShowSkuOnCatalogPages && !string.IsNullOrEmpty(Model.Sku))
+        {
+            <div class="sku">
+                @Model.Sku
+            </div>
+        }
+        @if (Model.ReviewOverviewModel.AllowCustomerReviews)
+        {
+            var ratingPercent = 0;
+            if (Model.ReviewOverviewModel.TotalReviews != 0)
+            {
+                ratingPercent = ((Model.ReviewOverviewModel.RatingSum * 100) / Model.ReviewOverviewModel.TotalReviews) / 5;
+            }
+            <div class="product-rating-box" title="@string.Format(T("Reviews.TotalReviews").Text, Model.ReviewOverviewModel.TotalReviews)">
+                <div class="rating">
+                    <div style="width: @(ratingPercent)%">
+                    </div>
+                </div>
+            </div>
+        }
+        <div class="description" @(catalogSettings.ShowShortDescriptionOnCatalogPages ? "" : "data-short-description=none")>
+            @Html.Raw(Model.ShortDescription)
+        </div>
+        <div class="add-info">
+            @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.ProductBoxAddinfoBefore, additionalData = Model })
+            <div class="prices">
+                @if (!string.IsNullOrEmpty(Model.ProductPrice.OldPrice))
+                {
+                    <span class="price old-price">@Model.ProductPrice.OldPrice</span>
+                }
+                <span class="price actual-price">@Model.ProductPrice.Price</span>
+                @if (Model.ProductPrice.DisplayTaxShippingInfo)
+                {
+                    var inclTax = await workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+                    //tax info is already included in the price (incl/excl tax). that's why we display only shipping info here
+                    //of course, you can modify appropriate locales to include VAT info there
+                    <span class="tax-shipping-info">
+                        @T(inclTax ? "Products.Price.TaxShipping.InclTax" : "Products.Price.TaxShipping.ExclTax", await NopUrl.RouteTopicUrlAsync("shippinginfo"))
+                    </span>
+                }
+                @if (!string.IsNullOrEmpty(Model.ProductPrice.BasePricePAngV))
+                {
+                    <div class="base-price-pangv">
+                        @Model.ProductPrice.BasePricePAngV
+                    </div>
+                }
+            </div>
+            @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.ProductBoxAddinfoMiddle, additionalData = Model })
+            <div class="buttons">
+                <a class="button-2 jb-view-job-button" href="@(await NopUrl.RouteGenericUrlAsync<Product>(new { SeName = Model.SeName }))">View job</a>
+                @if (!Model.ProductPrice.DisableBuyButton)
+                {
+                    var addToCartText = T("ShoppingCart.AddToCart").Text;
+                    if (Model.ProductPrice.IsRental)
+                    {
+                        addToCartText = T("ShoppingCart.Rent").Text;
+                    }
+                    if (Model.ProductPrice.AvailableForPreOrder)
+                    {
+                        addToCartText = T("ShoppingCart.PreOrder").Text;
+                    }
+                    <button type="button" class="button-2 product-box-add-to-cart-button" onclick="AjaxCart.addproducttocart_catalog('@addtocartlink');return false;">@(addToCartText)</button>
+                }
+                @if (!Model.ProductPrice.DisableAddToCompareListButton)
+                {
+                    <button type="button" class="button-2 add-to-compare-list-button" title="@T("ShoppingCart.AddToCompareList")" onclick="AjaxCart.addproducttocomparelist('@addtocomparelink');return false;">@T("ShoppingCart.AddToCompareList")</button>
+                }
+                @if (!Model.ProductPrice.DisableWishlistButton)
+                {
+                    @await Html.PartialAsync("_MoveToWishlistModal", Model.ProductToWishlist)
+
+                    <button type="button" class="button-2 add-to-wishlist-button" title="@T("ShoppingCart.AddToWishlist")" onclick="AjaxCart.addproducttocart_catalog('@addtowishlistlink');return false;">@T("ShoppingCart.AddToWishlist")</button>
+                }
+            </div>
+            @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.ProductBoxAddinfoAfter, additionalData = Model })
+        </div>
+    </div>
+</article>


### PR DESCRIPTION
Tightens the shared home/listing experience prior to job-detail design:
- Adds a guaranteed `View job` action on listing cards even when add-to-cart is disabled.
- Hides retail details (SKUs, titles, descriptions) inside home native components to keep focus on the job board UI.
- Preserves native models, widget zones, and previous mobile menu/footer fixes.

---
*PR created automatically by Jules for task [5840788518335873559](https://jules.google.com/task/5840788518335873559) started by @sateeshmunagala*